### PR TITLE
Add a config to database URL and handle SQLite driver configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 venv
 config.env
+*.db

--- a/repost/config.py
+++ b/repost/config.py
@@ -13,6 +13,7 @@ class Config:
     """Definition and defaults for package configuration."""
     jwt_secret: str = secrets.token_hex(32)
     jwt_algorithm: str = 'HS256'
+    database_url: str = 'sqlite:///./repost.db'
 
     def initialize(self):
         """Initialize and load the config instance."""

--- a/repost/database.py
+++ b/repost/database.py
@@ -1,12 +1,21 @@
 from sqlalchemy import create_engine
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "postgresql://postgres:roger123@127.0.0.1/db"
+from repost import config
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL
-)
+url = make_url(config.database_url)
+connect_args = {}
+
+# SQLite driver only allows one thread by default to prevent multiple
+# connections, but internally we are opening multiple connections so
+# multiple threads can be used
+if url.drivername == 'sqlite':
+    connect_args['check_same_thread'] = False
+
+engine = create_engine(url, connect_args=connect_args)
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()


### PR DESCRIPTION
SQLite is used as the default URL since it is included in python and will allow the application to work out of the box. This can easily be changed to another database driver by changing the DATABASE_URL configuration.