### PR TITLE
Create CRUD functions and implement endpoints for users

### DIFF
--- a/repost/api/resolvers.py
+++ b/repost/api/resolvers.py
@@ -20,7 +20,7 @@ def get_db():
         session.close()
 
 
-def resolve_user(db: Session = Depends(get_db), username: str = Path(...)) -> User:
+def resolve_user(username: str = Path(...), db: Session = Depends(get_db)) -> User:
     """Verify the user from path parameter.
 
     Base path: /users/{username}
@@ -32,9 +32,9 @@ def resolve_user(db: Session = Depends(get_db), username: str = Path(...)) -> Us
     return User.from_orm(db_user)
 
 
-async def resolve_current_user(db: Session = Depends(get_db), username: str = Depends(authorize_user)) -> User:
+async def resolve_current_user(username: str = Depends(authorize_user), db: Session = Depends(get_db)) -> User:
     """Resolve the currently authorized User."""
-    return resolve_user(db, username)
+    return resolve_user(username, db)
 
 
 async def resolve_resub(resub: str = Path(...)) -> Resub:

--- a/repost/api/resolvers.py
+++ b/repost/api/resolvers.py
@@ -1,6 +1,7 @@
 """Dependencies for resolving and verifying paths and ownership."""
 
 from fastapi import Path, Depends, HTTPException
+from sqlalchemy.orm import Session
 from starlette.status import HTTP_404_NOT_FOUND
 
 from repost import crud
@@ -19,7 +20,7 @@ def get_db():
         session.close()
 
 
-def resolve_user(db: Depends(get_db), username: str = Path(...)) -> User:
+def resolve_user(db: Session = Depends(get_db), username: str = Path(...)) -> User:
     """Verify the user from path parameter.
 
     Base path: /users/{username}

--- a/repost/api/resolvers.py
+++ b/repost/api/resolvers.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from starlette.status import HTTP_404_NOT_FOUND
 
 from repost import crud
-from repost.api.schemas import Resub, User, Post, Comment
+from repost import models
 from repost.api.security import authorize_user
 from repost.database import SessionLocal
 
@@ -20,7 +20,7 @@ def get_db():
         session.close()
 
 
-def resolve_user(username: str = Path(...), db: Session = Depends(get_db)) -> User:
+def resolve_user(username: str = Path(...), db: Session = Depends(get_db)) -> models.User:
     """Verify the user from path parameter.
 
     Base path: /users/{username}
@@ -29,15 +29,15 @@ def resolve_user(username: str = Path(...), db: Session = Depends(get_db)) -> Us
     if not db_user:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f'User \'{username}\' not found')
 
-    return User.from_orm(db_user)
+    return db_user
 
 
-async def resolve_current_user(username: str = Depends(authorize_user), db: Session = Depends(get_db)) -> User:
+async def resolve_current_user(username: str = Depends(authorize_user), db: Session = Depends(get_db)) -> models.User:
     """Resolve the currently authorized User."""
     return resolve_user(username, db)
 
 
-async def resolve_resub(resub: str = Path(...)) -> Resub:
+async def resolve_resub(resub: str = Path(...)) -> models.Resub:
     """Verify the resub from path parameter.
 
     Base path: /resubs/{resub}
@@ -45,8 +45,8 @@ async def resolve_resub(resub: str = Path(...)) -> Resub:
     pass
 
 
-async def resolve_user_owned_resub(resub: Resub = Depends(resolve_resub),
-                                   current_user: User = Depends(resolve_current_user)) -> Resub:
+async def resolve_user_owned_resub(resub: models.Resub = Depends(resolve_resub),
+                                   current_user: models.User = Depends(resolve_current_user)) -> models.Resub:
     """Verify that the authorized user owns the resub before returning.
 
     Base path: /resubs/{resub}
@@ -54,8 +54,8 @@ async def resolve_user_owned_resub(resub: Resub = Depends(resolve_resub),
     pass
 
 
-async def resolve_post(resub: Resub = Depends(resolve_resub),
-                       post_id: int = Path(...)) -> Post:
+async def resolve_post(resub: models.Resub = Depends(resolve_resub),
+                       post_id: int = Path(...)) -> models.Post:
     """Resolve the post from the path parameter.
 
     Base path: /resubs/{resub}/posts/{post_id}
@@ -63,8 +63,8 @@ async def resolve_post(resub: Resub = Depends(resolve_resub),
     pass
 
 
-async def resolve_user_owned_post(post: Post = Depends(resolve_post),
-                                  current_user: User = Depends(resolve_current_user)) -> Post:
+async def resolve_user_owned_post(post: models.Post = Depends(resolve_post),
+                                  current_user: models.User = Depends(resolve_current_user)) -> models.Post:
     """Verify that the authorized user owns the post before returning.
 
     Base path: /resubs/{resub}/posts/{post_id}
@@ -72,9 +72,10 @@ async def resolve_user_owned_post(post: Post = Depends(resolve_post),
     pass
 
 
-async def resolve_post_for_post_owner_or_resub_owner(resub: Resub = Depends(resolve_resub),
-                                                     post: Post = Depends(resolve_post),
-                                                     current_user: User = Depends(resolve_current_user)) -> Post:
+async def resolve_post_for_post_owner_or_resub_owner(resub: models.Resub = Depends(resolve_resub),
+                                                     post: models.Post = Depends(resolve_post),
+                                                     current_user: models.User = Depends(
+                                                         resolve_current_user)) -> models.Post:
     """Verify that the authorized user owns the post or owns the resub before returning.
 
     Base path: /resubs/{resub}/posts/{post_id}
@@ -82,21 +83,21 @@ async def resolve_post_for_post_owner_or_resub_owner(resub: Resub = Depends(reso
     pass
 
 
-async def resolve_comment(post: Post = Depends(resolve_post),
-                          comment_id: int = Path(...)) -> Comment:
+async def resolve_comment(post: models.Post = Depends(resolve_post),
+                          comment_id: int = Path(...)) -> models.Comment:
     """ Resolve the comment from the path parameter. """
     pass
 
 
-async def resolve_user_owned_comment(post: Comment = Depends(resolve_comment),
-                                     current_user: User = Depends(resolve_current_user)) -> Post:
+async def resolve_user_owned_comment(post: models.Comment = Depends(resolve_comment),
+                                     current_user: models.User = Depends(resolve_current_user)) -> models.Post:
     """ Verify that the authorized user owns the comment before returning. """
     pass
 
 
-async def resolve_comment_for_comment_owner_or_resub_owner(resub: Resub = Depends(resolve_resub),
-                                                           comment: Comment = Depends(resolve_comment),
-                                                           current_user: User = Depends(
-                                                               resolve_current_user)) -> Comment:
+async def resolve_comment_for_comment_owner_or_resub_owner(resub: models.Resub = Depends(resolve_resub),
+                                                           comment: models.Comment = Depends(resolve_comment),
+                                                           current_user: models.User = Depends(
+                                                               resolve_current_user)) -> models.Comment:
     """ Verify that the authorized user owns the comment or owns the resub before returning. """
     pass

--- a/repost/api/routes/auth.py
+++ b/repost/api/routes/auth.py
@@ -1,13 +1,26 @@
 """Router for authorization."""
-from fastapi import APIRouter, Depends
-from fastapi.security import OAuth2PasswordRequestForm
 
-from repost.api.schemas import OAuth2Token
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+from starlette.status import HTTP_403_FORBIDDEN
+
+from repost import crud
+from repost.api.resolvers import get_db
+from repost.api.schemas import OAuth2Token, ErrorResponse
+from repost.api.security import create_jwt_token
+from repost.password import verify_password
 
 router = APIRouter()
 
 
-@router.post('/token', response_model=OAuth2Token)
-async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+@router.post('/token', response_model=OAuth2Token,
+             responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse}})
+async def login(db: Session = Depends(get_db), form_data: OAuth2PasswordRequestForm = Depends()):
     """Authorize using username and password."""
-    pass
+    db_user = crud.get_user(db, username=form_data.username)
+
+    if not db_user or not verify_password(form_data.password, db_user.hashed_password):
+        raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail='Invalid login information')
+
+    return OAuth2Token(access_token=create_jwt_token(username=db_user.username), token_type='bearer')

--- a/repost/api/routes/comments.py
+++ b/repost/api/routes/comments.py
@@ -11,9 +11,8 @@ from fastapi import APIRouter, Depends
 from starlette.status import HTTP_404_NOT_FOUND, HTTP_403_FORBIDDEN
 
 from repost.api.resolvers import resolve_post, resolve_comment_for_comment_owner_or_resub_owner, resolve_comment, \
-    resolve_user_owned_comment
+    resolve_user_owned_comment, resolve_current_user
 from repost.api.schemas import Comment, Post, User, ErrorResponse, CreateComment, EditComment, Vote
-from repost.api.security import get_current_user
 
 router = APIRouter()
 
@@ -29,7 +28,7 @@ async def get_comments(post: Post = Depends(resolve_post)):
              responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse},
                         HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
 async def create_comment(*, post: Post = Depends(resolve_post), comment: CreateComment,
-                         current_user: User = Depends(get_current_user)):
+                         current_user: User = Depends(resolve_current_user)):
     """Create a comment in a post."""
     pass
 
@@ -61,7 +60,7 @@ async def edit_comment(*, comment: Comment = Depends(resolve_user_owned_comment)
               responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse},
                          HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
 async def vote_comment(*, comment: Comment = Depends(resolve_comment), vote: Vote,
-                       current_user: User = Depends(get_current_user)):
+                       current_user: User = Depends(resolve_current_user)):
     """Vote on a comment in a post."""
     pass
 
@@ -70,7 +69,6 @@ async def vote_comment(*, comment: Comment = Depends(resolve_comment), vote: Vot
              responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse},
                         HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
 async def create_reply(*, comment: Comment = Depends(resolve_comment), reply: CreateComment,
-                       current_user: User = Depends(get_current_user)):
+                       current_user: User = Depends(resolve_current_user)):
     """Create a reply to a comment in a post."""
     pass
-

--- a/repost/api/routes/posts.py
+++ b/repost/api/routes/posts.py
@@ -5,16 +5,14 @@ such every endpoint must resolve a resub. This is implemented in the
 resolvers in `repost.resolvers`.
 """
 
-
 from typing import List
 
 from fastapi import APIRouter, Depends
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
 
 from repost.api.resolvers import resolve_resub, resolve_post, resolve_user_owned_post, \
-    resolve_post_for_post_owner_or_resub_owner
+    resolve_post_for_post_owner_or_resub_owner, resolve_current_user
 from repost.api.schemas import ErrorResponse, User, Resub, CreatePost, Post, EditPost, Vote
-from repost.api.security import get_current_user
 
 router = APIRouter()
 
@@ -30,7 +28,7 @@ async def get_posts(resub: Resub = Depends(resolve_resub)):
              responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse},
                         HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
 async def create_post(*, resub: Resub = Depends(resolve_resub),
-                      post: CreatePost, user: User = Depends(get_current_user)):
+                      post: CreatePost, user: User = Depends(resolve_current_user)):
     """Create a new post in a resub."""
     pass
 
@@ -67,6 +65,7 @@ async def edit_post(*, post: Post = Depends(resolve_user_owned_post), edited_pos
 @router.patch('/{post_id}/{vote}',
               responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse},
                          HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def vote_post(*, post: Post = Depends(resolve_post), vote: Vote, current_user: User = Depends(get_current_user)):
+async def vote_post(*, post: Post = Depends(resolve_post), vote: Vote,
+                    current_user: User = Depends(resolve_current_user)):
     """Vote on a post in a resub."""
     pass

--- a/repost/api/routes/resubs.py
+++ b/repost/api/routes/resubs.py
@@ -9,9 +9,8 @@ from typing import List
 from fastapi import APIRouter, Depends
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST
 
-from repost.api.resolvers import resolve_resub, resolve_user_owned_resub
+from repost.api.resolvers import resolve_resub, resolve_user_owned_resub, resolve_current_user
 from repost.api.schemas import User, Resub, CreateResub, EditResub, ErrorResponse
-from repost.api.security import get_current_user
 
 router = APIRouter()
 
@@ -25,7 +24,7 @@ async def get_resubs():
 @router.post('/', response_model=Resub,
              responses={HTTP_400_BAD_REQUEST: {'model': ErrorResponse},
                         HTTP_403_FORBIDDEN: {'model': ErrorResponse}})
-async def create_resub(resub: CreateResub, current_user: User = Depends(get_current_user)):
+async def create_resub(resub: CreateResub, current_user: User = Depends(resolve_current_user)):
     """Create a new resub."""
     pass
 

--- a/repost/api/routes/users.py
+++ b/repost/api/routes/users.py
@@ -5,6 +5,7 @@ from typing import List
 from fastapi import APIRouter, Depends
 from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST, HTTP_403_FORBIDDEN
 
+from repost.api.resolvers import resolve_user
 from repost.api.schemas import User, CreateUser, Resub, Post, Comment, ErrorResponse, EditUser
 from repost.api.security import get_current_user
 
@@ -41,27 +42,27 @@ async def delete_current_user(current_user: User = Depends(get_current_user)):
 
 @router.get('/{username}', response_model=User,
             responses={HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def get_user(username: str):
+async def get_user(user: User = Depends(resolve_user)):
     """Get a specific user."""
-    pass
+    return user
 
 
 @router.get('/{username}/resubs', response_model=List[Resub],
             responses={HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def get_resubs_owned_by_user(username: str):
+async def get_resubs_owned_by_user(user: User = Depends(resolve_user)):
     """Get all resubs owned by a specific user."""
     pass
 
 
 @router.get('/{username}/posts', response_model=List[Post],
             responses={HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def get_posts_by_user(username: str):
+async def get_posts_by_user(user: User = Depends(resolve_user)):
     """Get all posts by a specific user."""
     pass
 
 
 @router.get('/{username}/comments', response_model=List[Comment],
             responses={HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def get_comments_by_user(username: str):
+async def get_comments_by_user(user: User = Depends(resolve_user)):
     """Get all comments by a specific user."""
     pass

--- a/repost/api/routes/users.py
+++ b/repost/api/routes/users.py
@@ -3,9 +3,11 @@
 from typing import List
 
 from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
 from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST, HTTP_403_FORBIDDEN
 
-from repost.api.resolvers import resolve_user
+from repost import crud
+from repost.api.resolvers import resolve_user, get_db
 from repost.api.schemas import User, CreateUser, Resub, Post, Comment, ErrorResponse, EditUser
 from repost.api.security import get_current_user
 
@@ -14,9 +16,9 @@ router = APIRouter()
 
 @router.post('/', response_model=User, status_code=HTTP_201_CREATED,
              responses={HTTP_400_BAD_REQUEST: {'model': ErrorResponse}})
-async def create_user(user: CreateUser):
+async def create_user(*, db: Session = Depends(get_db), user: CreateUser):
     """Create a new user."""
-    pass
+    return crud.create_user(db, user=user)
 
 
 @router.get('/me', response_model=User,

--- a/repost/api/routes/users.py
+++ b/repost/api/routes/users.py
@@ -7,9 +7,8 @@ from sqlalchemy.orm import Session
 from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST, HTTP_403_FORBIDDEN
 
 from repost import crud
-from repost.api.resolvers import resolve_user, get_db
+from repost.api.resolvers import resolve_user, get_db, resolve_current_user
 from repost.api.schemas import User, CreateUser, Resub, Post, Comment, ErrorResponse, EditUser
-from repost.api.security import get_current_user
 
 router = APIRouter()
 
@@ -23,9 +22,9 @@ async def create_user(*, db: Session = Depends(get_db), user: CreateUser):
 
 @router.get('/me', response_model=User,
             responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse}})
-async def get_current_user(current_user: User = Depends(get_current_user)):
+async def get_current_user(current_user: User = Depends(resolve_current_user)):
     """Get the currently authorized user."""
-    pass
+    return current_user
 
 
 @router.patch('/me', response_model=User,

--- a/repost/api/routes/users.py
+++ b/repost/api/routes/users.py
@@ -15,7 +15,7 @@ router = APIRouter()
 
 @router.post('/', response_model=User, status_code=HTTP_201_CREATED,
              responses={HTTP_400_BAD_REQUEST: {'model': ErrorResponse}})
-async def create_user(*, db: Session = Depends(get_db), user: CreateUser):
+async def create_user(user: CreateUser, db: Session = Depends(get_db)):
     """Create a new user."""
     return crud.create_user(db, user=user)
 
@@ -29,16 +29,17 @@ async def get_current_user(current_user: User = Depends(resolve_current_user)):
 
 @router.patch('/me', response_model=User,
               responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse}})
-async def edit_current_user(*, current_user: User = Depends(get_current_user), edited_user: EditUser):
+async def edit_current_user(*, current_user: User = Depends(get_current_user), edited_user: EditUser,
+                            db: Session = Depends(get_db)):
     """Edit the currently authorized user."""
-    pass
+    return crud.update_user(db, username=current_user.username, user=edited_user)
 
 
 @router.delete('/me',
                responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse}})
-async def delete_current_user(current_user: User = Depends(get_current_user)):
+async def delete_current_user(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     """Delete the currently authorized user."""
-    pass
+    crud.delete_user(db, username=current_user.username)
 
 
 @router.get('/{username}', response_model=User,

--- a/repost/api/routes/users.py
+++ b/repost/api/routes/users.py
@@ -17,7 +17,7 @@ router = APIRouter()
              responses={HTTP_400_BAD_REQUEST: {'model': ErrorResponse}})
 async def create_user(user: CreateUser, db: Session = Depends(get_db)):
     """Create a new user."""
-    return crud.create_user(db, user=user)
+    return crud.create_user(db, username=user.username, password=user.password)
 
 
 @router.get('/me', response_model=User,
@@ -32,7 +32,7 @@ async def get_current_user(current_user: User = Depends(resolve_current_user)):
 async def edit_current_user(*, current_user: User = Depends(get_current_user), edited_user: EditUser,
                             db: Session = Depends(get_db)):
     """Edit the currently authorized user."""
-    return crud.update_user(db, username=current_user.username, user=edited_user)
+    return crud.update_user(db, username=current_user.username, **edited_user.dict(exclude_unset=True))
 
 
 @router.delete('/me',

--- a/repost/api/routes/users.py
+++ b/repost/api/routes/users.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND, HTTP_400_BAD_REQUEST, HTTP_403_FORBIDDEN
 
-from repost import crud
+from repost import crud, models
 from repost.api.resolvers import resolve_user, get_db, resolve_current_user
 from repost.api.schemas import User, CreateUser, Resub, Post, Comment, ErrorResponse, EditUser
 
@@ -22,14 +22,14 @@ async def create_user(user: CreateUser, db: Session = Depends(get_db)):
 
 @router.get('/me', response_model=User,
             responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse}})
-async def get_current_user(current_user: User = Depends(resolve_current_user)):
+async def get_current_user(current_user: models.User = Depends(resolve_current_user)):
     """Get the currently authorized user."""
     return current_user
 
 
 @router.patch('/me', response_model=User,
               responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse}})
-async def edit_current_user(*, current_user: User = Depends(get_current_user), edited_user: EditUser,
+async def edit_current_user(*, current_user: models.User = Depends(get_current_user), edited_user: EditUser,
                             db: Session = Depends(get_db)):
     """Edit the currently authorized user."""
     return crud.update_user(db, username=current_user.username, **edited_user.dict(exclude_unset=True))
@@ -37,34 +37,34 @@ async def edit_current_user(*, current_user: User = Depends(get_current_user), e
 
 @router.delete('/me',
                responses={HTTP_403_FORBIDDEN: {'model': ErrorResponse}})
-async def delete_current_user(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+async def delete_current_user(current_user: models.User = Depends(get_current_user), db: Session = Depends(get_db)):
     """Delete the currently authorized user."""
     crud.delete_user(db, username=current_user.username)
 
 
 @router.get('/{username}', response_model=User,
             responses={HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def get_user(user: User = Depends(resolve_user)):
+async def get_user(user: models.User = Depends(resolve_user)):
     """Get a specific user."""
     return user
 
 
 @router.get('/{username}/resubs', response_model=List[Resub],
             responses={HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def get_resubs_owned_by_user(user: User = Depends(resolve_user)):
+async def get_resubs_owned_by_user(user: models.User = Depends(resolve_user)):
     """Get all resubs owned by a specific user."""
     pass
 
 
 @router.get('/{username}/posts', response_model=List[Post],
             responses={HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def get_posts_by_user(user: User = Depends(resolve_user)):
+async def get_posts_by_user(user: models.User = Depends(resolve_user)):
     """Get all posts by a specific user."""
     pass
 
 
 @router.get('/{username}/comments', response_model=List[Comment],
             responses={HTTP_404_NOT_FOUND: {'model': ErrorResponse}})
-async def get_comments_by_user(user: User = Depends(resolve_user)):
+async def get_comments_by_user(user: models.User = Depends(resolve_user)):
     """Get all comments by a specific user."""
     pass

--- a/repost/api/schemas/comment.py
+++ b/repost/api/schemas/comment.py
@@ -1,22 +1,19 @@
 """API schemas for comments."""
 
 from datetime import datetime
-from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, Field
-
-from .user import User
 
 
 class Comment(BaseModel):
     """Schema for a comment in a post"""
     id: int
     parent_resub_name: str = Field(..., description='Name of the parent resub the comment was created in')
-    parent_post_name: str = Field(..., description='ID of the parent post the comment was created in')
+    parent_post_id: int = Field(..., description='ID of the parent post the comment was created in')
     parent_comment_id: Optional[int] = Field(..., description='ID of the parent comment when the comment is a reply')
     content: str
-    author: str
+    author_name: str
     created: datetime
     edited: Optional[datetime]
     votes: int

--- a/repost/api/schemas/comment.py
+++ b/repost/api/schemas/comment.py
@@ -13,7 +13,7 @@ class Comment(BaseModel):
     parent_post_id: int = Field(..., description='ID of the parent post the comment was created in')
     parent_comment_id: Optional[int] = Field(..., description='ID of the parent comment when the comment is a reply')
     content: str
-    author_name: str
+    author_username: str = Field(..., description='Username of the author of the comment')
     created: datetime
     edited: Optional[datetime]
     votes: int

--- a/repost/api/schemas/post.py
+++ b/repost/api/schemas/post.py
@@ -1,12 +1,9 @@
 """API schemas for posts."""
 
-
 from datetime import datetime
 from typing import Optional
 
 from pydantic import Field, BaseModel
-
-from .user import User
 
 
 class Post(BaseModel):
@@ -16,7 +13,7 @@ class Post(BaseModel):
     title: str
     url: Optional[str]
     content: Optional[str]
-    author: str
+    author_name: str
     created: datetime
     edited: Optional[datetime]
     votes: int

--- a/repost/api/schemas/post.py
+++ b/repost/api/schemas/post.py
@@ -13,7 +13,7 @@ class Post(BaseModel):
     title: str
     url: Optional[str]
     content: Optional[str]
-    author_name: str
+    author_username: str = Field(..., description='Username of the author of the post')
     created: datetime
     edited: Optional[datetime]
     votes: int

--- a/repost/api/schemas/resub.py
+++ b/repost/api/schemas/resub.py
@@ -3,8 +3,6 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from .user import User
-
 
 class Resub(BaseModel):
     """Schema for a resub
@@ -14,7 +12,7 @@ class Resub(BaseModel):
     """
     name: str
     description: Optional[str]
-    owner_id: int
+    owner_name: str
 
 
 class CreateResub(BaseModel):

--- a/repost/api/schemas/resub.py
+++ b/repost/api/schemas/resub.py
@@ -12,7 +12,7 @@ class Resub(BaseModel):
     """
     name: str
     description: Optional[str]
-    owner_name: str
+    owner_username: str = Field(..., description='Username of the owner of the resub')
 
 
 class CreateResub(BaseModel):

--- a/repost/api/schemas/user.py
+++ b/repost/api/schemas/user.py
@@ -1,5 +1,5 @@
 """API schemas for users."""
-
+from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel
@@ -10,6 +10,10 @@ class User(BaseModel):
     username: str
     bio: str
     avatar_url: Optional[str]
+    created: datetime
+
+    class Config:
+        orm_mode = True
 
 
 class CreateUser(BaseModel):

--- a/repost/api/schemas/user.py
+++ b/repost/api/schemas/user.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 class User(BaseModel):
     """Schema for a user account"""
     username: str
-    bio: str
+    bio: Optional[str]
     avatar_url: Optional[str]
     created: datetime
 
@@ -24,5 +24,5 @@ class CreateUser(BaseModel):
 
 class EditUser(BaseModel):
     """Schema for editing a user account"""
-    bio: str = None
-    avatar_url: str = None
+    bio: Optional[str] = None
+    avatar_url: Optional[str] = None

--- a/repost/api/security.py
+++ b/repost/api/security.py
@@ -33,7 +33,7 @@ async def authorize_user(jwt_token: str = Depends(oauth2_scheme)) -> str:
     """Validate and return the username in the JSON Web Token."""
     try:
         return get_jwt_token_username(jwt_token)
-    except jwt.exceptions.ExpiredSignatureError as e:
+    except jwt.exceptions.ExpiredSignatureError:
         raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail='The JSON Web Token has expired')
     except jwt.exceptions.DecodeError as e:
         raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=f'Failed to parse JSON Web Token: {str(e)}')

--- a/repost/crud/__init__.py
+++ b/repost/crud/__init__.py
@@ -1,0 +1,1 @@
+from .users import get_user, create_user, update_user, delete_user

--- a/repost/crud/users.py
+++ b/repost/crud/users.py
@@ -1,0 +1,34 @@
+from sqlalchemy.orm import Session
+
+from repost.api.schemas import CreateUser, EditUser
+from repost.models import User
+from repost.password import hash_password
+
+
+def get_user(db: Session, *, username: str) -> User:
+    """Get the user with the given username."""
+    return db.query(User).filter(User.username == username).first()
+
+
+def create_user(db: Session, *, user: CreateUser) -> User:
+    """Create a new user in the database."""
+    db_user = User(username=user.username, hashed_password=hash_password(user.password))
+    db.add(db_user)
+    db.commit()
+
+    db.refresh(db_user)
+    return db_user
+
+
+def update_user(db: Session, *, username: str, user: EditUser) -> User:
+    """Edit the user with the given username."""
+    db.query(User).filter(User.username == username).update(user.dict(exclude_unset=True))
+    db.commit()
+
+    return get_user(db, username=username)
+
+
+def delete_user(db: Session, *, username: str):
+    """Delete the user with the given username."""
+    db.query(User).filter(User.username == username).delete()
+    db.commit()

--- a/repost/crud/users.py
+++ b/repost/crud/users.py
@@ -1,6 +1,7 @@
+from typing import Any
+
 from sqlalchemy.orm import Session
 
-from repost.api.schemas import CreateUser, EditUser
 from repost.models import User
 from repost.password import hash_password
 
@@ -10,9 +11,9 @@ def get_user(db: Session, *, username: str) -> User:
     return db.query(User).filter(User.username == username).first()
 
 
-def create_user(db: Session, *, user: CreateUser) -> User:
+def create_user(db: Session, *, username: str, password: str) -> User:
     """Create a new user in the database."""
-    db_user = User(username=user.username, hashed_password=hash_password(user.password))
+    db_user = User(username=username, hashed_password=hash_password(password))
     db.add(db_user)
     db.commit()
 
@@ -20,9 +21,12 @@ def create_user(db: Session, *, user: CreateUser) -> User:
     return db_user
 
 
-def update_user(db: Session, *, username: str, user: EditUser) -> User:
-    """Edit the user with the given username."""
-    db.query(User).filter(User.username == username).update(user.dict(exclude_unset=True))
+def update_user(db: Session, *, username: str, **columns: Any) -> User:
+    """Edit the user with the given username.
+
+    Enter any `repost.models.User` column to update in `**columns`.
+    """
+    db.query(User).filter(User.username == username).update(columns)
     db.commit()
 
     return get_user(db, username=username)

--- a/repost/crud/users.py
+++ b/repost/crud/users.py
@@ -2,18 +2,18 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
-from repost.models import User
+from repost import models
 from repost.password import hash_password
 
 
-def get_user(db: Session, *, username: str) -> User:
+def get_user(db: Session, *, username: str) -> models.User:
     """Get the user with the given username."""
-    return db.query(User).filter(User.username == username).first()
+    return db.query(models.User).filter_by(username=username).first()
 
 
-def create_user(db: Session, *, username: str, password: str) -> User:
+def create_user(db: Session, *, username: str, password: str) -> models.User:
     """Create a new user in the database."""
-    db_user = User(username=username, hashed_password=hash_password(password))
+    db_user = models.User(username=username, hashed_password=hash_password(password))
     db.add(db_user)
     db.commit()
 
@@ -21,12 +21,12 @@ def create_user(db: Session, *, username: str, password: str) -> User:
     return db_user
 
 
-def update_user(db: Session, *, username: str, **columns: Any) -> User:
+def update_user(db: Session, *, username: str, **columns: Any) -> models.User:
     """Edit the user with the given username.
 
     Enter any `repost.models.User` column to update in `**columns`.
     """
-    db.query(User).filter(User.username == username).update(columns)
+    db.query(models.User).filter_by(username=username).update(columns)
     db.commit()
 
     return get_user(db, username=username)
@@ -34,5 +34,5 @@ def update_user(db: Session, *, username: str, **columns: Any) -> User:
 
 def delete_user(db: Session, *, username: str):
     """Delete the user with the given username."""
-    db.query(User).filter(User.username == username).delete()
+    db.query(models.User).filter_by(username=username).delete()
     db.commit()

--- a/repost/models/comment.py
+++ b/repost/models/comment.py
@@ -12,9 +12,9 @@ class Comment(Base):
     created = Column(DateTime)
     edited = Column(DateTime, nullable=True)
 
-    author_id = Column(String, ForeignKey('users.id'))
-    parent_resub_id = Column(String, ForeignKey('resubs.id'))
-    parent_post_id = Column(String, ForeignKey('posts.id'))
+    author_id = Column(Integer, ForeignKey('users.id'))
+    parent_resub_id = Column(Integer, ForeignKey('resubs.id'))
+    parent_post_id = Column(Integer, ForeignKey('posts.id'))
     parent_comment_id = Column(Integer, ForeignKey('comments.id'), nullable=True)
 
     author = relationship('User', back_populates='comments')

--- a/repost/models/comment.py
+++ b/repost/models/comment.py
@@ -12,11 +12,10 @@ class Comment(Base):
     created = Column(DateTime)
     edited = Column(DateTime, nullable=True)
 
-    author_name = Column(String, ForeignKey('users.id'))
-    parent_resub_name = Column(String, ForeignKey('resubs.name'))
-    parent_post_name = Column(String, ForeignKey('posts.title'))
+    author_id = Column(String, ForeignKey('users.id'))
+    parent_resub_id = Column(String, ForeignKey('resubs.id'))
+    parent_post_id = Column(String, ForeignKey('posts.id'))
     parent_comment_id = Column(Integer, ForeignKey('comment.id'), nullable=True)
-    votes = Column(Integer)
 
     author = relationship('User', back_populates='comments')
     parent_resub = relationship('Resub', back_populates='comments')

--- a/repost/models/comment.py
+++ b/repost/models/comment.py
@@ -15,7 +15,7 @@ class Comment(Base):
     author_id = Column(String, ForeignKey('users.id'))
     parent_resub_id = Column(String, ForeignKey('resubs.id'))
     parent_post_id = Column(String, ForeignKey('posts.id'))
-    parent_comment_id = Column(Integer, ForeignKey('comment.id'), nullable=True)
+    parent_comment_id = Column(Integer, ForeignKey('comments.id'), nullable=True)
 
     author = relationship('User', back_populates='comments')
     parent_resub = relationship('Resub', back_populates='comments')

--- a/repost/models/post.py
+++ b/repost/models/post.py
@@ -14,8 +14,8 @@ class Post(Base):
     created = Column(DateTime)
     edited = Column(DateTime, nullable=True)
 
-    author_id = Column(String, ForeignKey('users.id'))
-    parent_resub_id = Column(String, ForeignKey('resubs.id'))
+    author_id = Column(Integer, ForeignKey('users.id'))
+    parent_resub_id = Column(Integer, ForeignKey('resubs.id'))
 
     author = relationship('User', back_populates='posts')
     parent_resub = relationship('Resub', back_populates='posts')

--- a/repost/models/post.py
+++ b/repost/models/post.py
@@ -13,10 +13,9 @@ class Post(Base):
     content = Column(String, nullable=True)
     created = Column(DateTime)
     edited = Column(DateTime, nullable=True)
-    votes = Column(Integer)
 
-    author_name = Column(String, ForeignKey('users.username'))
-    parent_resub_name = Column(String, ForeignKey('resubs.name'))
+    author_id = Column(String, ForeignKey('users.id'))
+    parent_resub_id = Column(String, ForeignKey('resubs.id'))
 
     author = relationship('User', back_populates='posts')
     parent_resub = relationship('Resub', back_populates='posts')

--- a/repost/models/user.py
+++ b/repost/models/user.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Column, Integer, String
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.orm import relationship
 
 from . import Base
@@ -11,6 +13,7 @@ class User(Base):
     username = Column(String, unique=True, index=True)
     bio = Column(String)
     avatar_url = Column(String, nullable=True)
+    created = Column(DateTime, default=datetime.utcnow)
 
     hashed_password = Column(String)
 

--- a/repost/password.py
+++ b/repost/password.py
@@ -2,7 +2,6 @@
 
 from passlib.context import CryptContext
 
-
 password_context = CryptContext(schemes=['bcrypt'], deprecated='auto')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ sqlalchemy==1.3.13
 fastapi==0.48.0
 uvicorn==0.11.2
 pyjwt==1.7.1
-python-dotenv==0.10.5
+python-dotenv==0.11.0
+python-multipart==0.0.5
 passlib[bcrypt]==1.7.2


### PR DESCRIPTION
This includes authorization, so the JWT functions are now used to authorize and authenticate users.

Still missing `resub`, `comment` and `post` endpoints. Refer to #26.

Resolves #20 
Also resolves #18 in that `resolve_current_user` uses `resolve_user`, which will inherently raise `404 Not Found` for any tokens with a username for a user that doesn't exist.

### Some discussion

Currently the CRUD function for `update_user` uses `**columns` in order to easily modify only the requested columns. This ties in nicely with the API schema, which can simply be written as:

```py
**edited_user.dict(exclude_unset=True)
``` 

The drawback of this solution is that the modifiable columns are not documented in the `update_user` functions. But at the same time, it makes it very easy to implement in both the API and the CRUD aspect.