### PR TITLE
Add app to __init__.py for more sensible startup

### DIFF
--- a/repost/__init__.py
+++ b/repost/__init__.py
@@ -1,1 +1,4 @@
 from .config import config
+
+# Needs to be bottom level import
+from .main import app


### PR DESCRIPTION
App can now be run with ASGI using `repost:app` as a parameter, instead of `repost.main:app`.