### PR TITLE
Update vote path and cascade delete votes

### DIFF
--- a/repost/api/routes/comments.py
+++ b/repost/api/routes/comments.py
@@ -79,7 +79,7 @@ async def edit_comment(*, comment: models.Comment = Depends(resolve_user_owned_c
     return crud.update_comment(db, comment_id=comment.id, **edited_comment.dict(exclude_unset=True))
 
 
-@router.patch('/{comment_id}/{vote}', response_model=Comment,
+@router.patch('/{comment_id}/vote/{vote}', response_model=Comment,
               responses={HTTP_400_BAD_REQUEST: {'model': ErrorResponse},
                          HTTP_401_UNAUTHORIZED: {'model': ErrorResponse},
                          HTTP_404_NOT_FOUND: {'model': ErrorResponse}})

--- a/repost/api/routes/posts.py
+++ b/repost/api/routes/posts.py
@@ -76,7 +76,7 @@ async def edit_post(*, post: models.Post = Depends(resolve_user_owned_post), edi
     return crud.update_post(db, post_id=post.id, **edited_post.dict(exclude_unset=True))
 
 
-@router.patch('/{post_id}/{vote}', response_model=Post,
+@router.patch('/{post_id}/vote/{vote}', response_model=Post,
               responses={HTTP_400_BAD_REQUEST: {'model': ErrorResponse},
                          HTTP_401_UNAUTHORIZED: {'model': ErrorResponse},
                          HTTP_404_NOT_FOUND: {'model': ErrorResponse}})

--- a/repost/crud/comments.py
+++ b/repost/crud/comments.py
@@ -29,7 +29,8 @@ def create_comment(db: Session, *, author_id: int, parent_post_id: int, parent_r
 
 def delete_comment(db: Session, comment_id: int):
     """Delete the comment with the given ID."""
-    db.query(Comment).filter_by(id=comment_id).delete()
+    db_comment = db.query(Comment).filter_by(id=comment_id).first()
+    db.delete(db_comment)
     db.commit()
 
 

--- a/repost/crud/posts.py
+++ b/repost/crud/posts.py
@@ -39,7 +39,8 @@ def update_post(db: Session, *, post_id: int, **columns: Any) -> Post:
 
 def delete_post(db: Session, *, post_id: int):
     """Delete the post with the given ID."""
-    db.query(Post).filter_by(id=post_id).delete()
+    db_post = db.query(Post).filter_by(id=post_id).first()
+    db.delete(db_post)
     db.commit()
 
 

--- a/repost/models/comment.py
+++ b/repost/models/comment.py
@@ -21,7 +21,7 @@ class Comment(Base):
     parent_resub = relationship('Resub', back_populates='comments')
     parent_post = relationship('Post', back_populates='comments')
     replies = relationship('Comment')
-    votes = relationship('CommentVote')
+    votes = relationship('CommentVote', cascade='delete')
 
 
 class CommentVote(Base):

--- a/repost/models/post.py
+++ b/repost/models/post.py
@@ -20,7 +20,7 @@ class Post(Base):
     author = relationship('User', back_populates='posts')
     parent_resub = relationship('Resub', back_populates='posts')
     comments = relationship('Comment', back_populates='parent_post')
-    votes = relationship('PostVote')
+    votes = relationship('PostVote', cascade='delete')
 
 
 class PostVote(Base):


### PR DESCRIPTION
Votes were previously left behind when deleting a post/comment. This meant that new posts with the same ID would be assigned those votes.

The same considerations need to be applied to deletion of any other object. A note for this discussion is created in https://github.com/pckv/repost-fastapi/projects/1