### PR TITLE
Implement OAuth2 client_id and scope validation

### DIFF
--- a/repost/api/resolvers.py
+++ b/repost/api/resolvers.py
@@ -1,6 +1,6 @@
 """Dependencies for resolving and verifying paths and ownership."""
 
-from fastapi import Path, Depends, HTTPException, status
+from fastapi import Path, Depends, HTTPException, status, Security
 from sqlalchemy.orm import Session
 
 from repost import crud
@@ -31,7 +31,8 @@ def resolve_user(username: str = Path(...), db: Session = Depends(get_db)) -> mo
     return db_user
 
 
-async def resolve_current_user(username: str = Depends(authorize_user), db: Session = Depends(get_db)) -> models.User:
+async def resolve_current_user(username: str = Security(authorize_user, scopes=['user']),
+                               db: Session = Depends(get_db)) -> models.User:
     """Resolve the currently authorized User."""
     db_user = crud.get_user(db, username=username)
     if not db_user:

--- a/repost/api/routes/auth.py
+++ b/repost/api/routes/auth.py
@@ -1,13 +1,14 @@
 """Router for authorization."""
+from base64 import b64decode
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Header
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
-from repost import crud
+from repost import crud, config
 from repost.api.resolvers import get_db
 from repost.api.schemas import OAuth2Token, ErrorResponse
-from repost.api.security import create_jwt_token
+from repost.api.security import create_jwt_token, oauth2_scopes
 from repost.password import verify_password
 
 router = APIRouter()
@@ -30,4 +31,6 @@ async def login(db: Session = Depends(get_db), form_data: OAuth2PasswordRequestF
     if not db_user or not verify_password(form_data.password, db_user.hashed_password):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid login information')
 
-    return OAuth2Token(access_token=create_jwt_token(username=db_user.username), token_type='bearer')
+    scopes = form_data.scopes or list(oauth2_scopes.keys())
+    return OAuth2Token(access_token=create_jwt_token(username=db_user.username, scopes=scopes),
+                       token_type='bearer', scope=' '.join(scopes))

--- a/repost/api/schemas/auth.py
+++ b/repost/api/schemas/auth.py
@@ -7,3 +7,4 @@ class OAuth2Token(BaseModel):
     """Schema for an OAuth2 token"""
     access_token: str
     token_type: str
+    scope: str

--- a/repost/api/security.py
+++ b/repost/api/security.py
@@ -1,37 +1,46 @@
 """Secure utility functions and setup."""
 
 from datetime import timedelta, datetime
+from typing import List
 
 import jwt
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security import OAuth2PasswordBearer, SecurityScopes
 
 from repost import config
 
+oauth2_scopes = {'user': 'User access'}
+
 # NOTE: this path is hardcoded and correlates to repost.api.routes.auth.login
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl='/api/auth/token')
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl='/api/auth/token', scopes=oauth2_scopes)
 
 
-def create_jwt_token(username: str, expire_delta: timedelta = timedelta(days=7)) -> str:
+def create_jwt_token(username: str, expire_delta: timedelta = timedelta(days=7), scopes: List[str] = None) -> str:
     """Create JSON Web Token with a username as the subject"""
     expire = datetime.utcnow() + expire_delta
 
-    data = {'sub': username, 'exp': expire}
+    data = {'sub': username, 'exp': expire, 'scopes': scopes or []}
     jwt_token = jwt.encode(data, config.jwt_secret, algorithm=config.jwt_algorithm)
     return jwt_token
 
 
-def get_jwt_token_username(jwt_token: str) -> str:
-    """Get username by decoding JSON Web Token"""
-    data = jwt.decode(jwt_token, config.jwt_secret, config.jwt_algorithm)
-    username = data.get('sub')
-    return username
+def decode_jwt_token(jwt_token: str) -> dict:
+    """Decode a JSON Web Token"""
+    return jwt.decode(jwt_token, key=config.jwt_secret, verify=config.jwt_algorithm)
 
 
-async def authorize_user(jwt_token: str = Depends(oauth2_scheme)) -> str:
+async def authorize_user(security_scopes: SecurityScopes, jwt_token: str = Depends(oauth2_scheme)) -> str:
     """Validate and return the username in the JSON Web Token."""
+    payload = decode_jwt_token(jwt_token)
+
+    # Verify that the user has the required scopes for this endpoint
+    scopes = payload.get('scopes', [])
+    for scope in security_scopes.scopes:
+        if scope not in scopes:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f'Missing scope \'{scope}\'')
+
     try:
-        return get_jwt_token_username(jwt_token)
+        return payload.get('sub')
     except jwt.exceptions.ExpiredSignatureError:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='The JSON Web Token has expired')
     except jwt.exceptions.DecodeError as e:

--- a/repost/config.py
+++ b/repost/config.py
@@ -11,6 +11,7 @@ env_path = Path.cwd() / 'config.env'
 @dataclass
 class Config:
     """Definition and defaults for package configuration."""
+    client_id: str = 'repost'
     jwt_secret: str = secrets.token_hex(32)
     jwt_algorithm: str = 'HS256'
     database_url: str = 'sqlite:///./repost.db'

--- a/repost/config.py
+++ b/repost/config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 env_path = Path.cwd() / 'config.env'
+env_prefix = 'REPOST_'
 
 
 @dataclass
@@ -21,13 +22,13 @@ class Config:
         # Initialize config file with defaults if it does not exist
         if not env_path.exists():
             with env_path.open(mode='w') as f:
-                f.write('\n'.join(f'{key.upper()}={value}' for key, value in asdict(self).items()) + '\n')
+                f.write('\n'.join(f'{env_prefix}{key.upper()}={value}' for key, value in asdict(self).items()) + '\n')
 
         load_dotenv(dotenv_path=env_path, verbose=True)
 
         # Add environment variables to configurations
         for key, default in asdict(self).items():
-            setattr(self, key, os.getenv(key.upper(), default))
+            setattr(self, key, os.getenv(env_prefix + key.upper(), default))
 
 
 config = Config()


### PR DESCRIPTION
This PR ensures OAuth2 consistency with pckv/repost-aspnet and EspenK/repost-spring by validating client_id and checking OAuth2 scopes. 

There is only one scope `user`, and providing no scope will by default choose all scopes. Therefore, a token issued by the server should always have only the `user` scope in Swagger UI. 