### PR TITLE
Initialize config in its own instance

### DIFF
--- a/repost/config.py
+++ b/repost/config.py
@@ -1,3 +1,5 @@
+"""Singleton configuration based on environment variables."""
+
 import os
 import secrets
 from dataclasses import dataclass, asdict
@@ -17,7 +19,7 @@ class Config:
     jwt_algorithm: str = 'HS256'
     database_url: str = 'sqlite:///./repost.db'
 
-    def initialize(self):
+    def __init__(self):
         """Initialize and load the config instance."""
         # Initialize config file with defaults if it does not exist
         if not env_path.exists():

--- a/repost/main.py
+++ b/repost/main.py
@@ -9,11 +9,9 @@ __version__ = '0.0.1'
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from repost import models, config
+from repost import models
 from repost.api import api_router
 from repost.database import engine
-
-config.initialize()
 
 app = FastAPI(title='Repost', version=__version__, description=__doc__,
               docs_url='/api/swagger', redoc_url='/api/docs')


### PR DESCRIPTION
This prevents the config from not being loaded before accessing properties.